### PR TITLE
Support for stateful Lambdas and multi-shard Kinesis streams

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 Changelog
 =========
 
-0.1.0
+0.2.0
+-----
+
+- Support for stateful Lambdas with multi-shard Kinesis streams
+
+0.1.1
 -----
 
 - Cleanup package data (bubenkoff)

--- a/humilis_kinesis_mapper/__init__.py
+++ b/humilis_kinesis_mapper/__init__.py
@@ -1,2 +1,2 @@
 """Humilis kinesis mapper."""
-__version__ = '0.1.1'
+__version__ = '0.2.0'

--- a/humilis_kinesis_mapper/lambda_function/handler/__init__.py
+++ b/humilis_kinesis_mapper/lambda_function/handler/__init__.py
@@ -3,26 +3,35 @@ from .processor.main import process_event
 import lambdautils.utils as utils
 from werkzeug.utils import import_string  # NOQA
 
-globs = dict(import_string=import_string, callables=[])
-
 # preprocessor:jinja2
+
+callables_globs = dict(import_string=import_string, callables=[])
 try:
     exec(
         """callables = [
         {% for name in callables %}
             import_string("{{name}}"),
         {% endfor %}
-    ]""", globs)
+    ]""", callables_globs)
 except SyntaxError:
     pass
-callables = globs['callables']
+callables = callables_globs["callables"]
+
+
+pkey_globs = dict(import_string=import_string, pkey=None)
+try:
+    exec(
+        """pkey = import_string("{{name}})""", pkey_globs)
+except SyntaxError:
+    pass
+partition_key = pkey_globs["pkey"]
 
 
 @utils.sentry_monitor(
     environment="{{_env.name}}",
     stage="{{_env.stage}}",
     layer="{{_layer.name}}",
-    error_delivery_stream="{{error_delivery_stream and error_delivery_stream.name}}",
+    error_delivery_stream="{{error_delivery_stream and error_delivery_stream.name}}",  # noqa
     error_stream="{{error_stream and error_stream.name}}")
 def lambda_handler(event, context):
     """Lambda function."""
@@ -31,5 +40,9 @@ def lambda_handler(event, context):
         "{{output_stream and output_stream.name}}",
         "{{input_delivery_stream and input_delivery_stream.name}}",
         "{{output_delivery_stream and output_delivery_stream.name}}",
+        "{{_env.name}}",
+        "{{_layer.name}}",
+        "{{_env.stage}}",
         callables,
+        partition_key
     )

--- a/humilis_kinesis_mapper/lambda_function/handler/processor/core.py
+++ b/humilis_kinesis_mapper/lambda_function/handler/processor/core.py
@@ -6,9 +6,10 @@
 def transform_events(events, callables, environment, layer, stage, shard_id):
     """Transforms events with the given callables."""
 
+    state_args = dict(environment=environment, layer=layer, stage=stage,
+                      shard_id=shard_id)
     for event in events:
         for cal in callables:
-            cal(event, environment=environment, layer=layer, stage=stage,
-                shard_id=shard_id)
+            cal(event, state_args=state_args)
 
     return events

--- a/humilis_kinesis_mapper/lambda_function/handler/processor/core.py
+++ b/humilis_kinesis_mapper/lambda_function/handler/processor/core.py
@@ -1,20 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import json
-import logging
-
 # preprocessor:jinja2
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
+def transform_events(events, callables, environment, layer, stage, shard_id):
+    """Transforms events with the given callables."""
 
-def transform_events(events, callables):
-    """Parses the user agents."""
     for event in events:
-        logger.info("Input event: {}".format(json.dumps(event, indent=4)))
         for cal in callables:
-            cal(event)
-        logger.info("Mapped event: {}".format(json.dumps(event, indent=4)))
+            cal(event, environment=environment, layer=layer, stage=stage,
+                shard_id=shard_id)
 
     return events

--- a/humilis_kinesis_mapper/lambda_function/handler/processor/main.py
+++ b/humilis_kinesis_mapper/lambda_function/handler/processor/main.py
@@ -15,40 +15,55 @@ logger.setLevel(logging.INFO)
 
 def process_event(
         kinesis_event, context, output_stream_name, input_delivery_stream_name,
-        output_delivery_stream_name, callables):
+        output_delivery_stream_name, environment, layer, stage, callables,
+        partition_key):
     """Forwards events to a Kinesis stream (for further processing) and
     to a Kinesis Firehose delivery stream (for persistence in S3 and/or
     Redshift)"""
-    events = utils.unpack_kinesis_event(kinesis_event,
-                                        deserializer=json.loads)
-    logger.info("Going to transform {} events".format(len(events)))
-    output_events = core.transform_events(events, callables)
-    logger.info(json.dumps(output_events, indent=4))
+    events, shard_id = utils.unpack_kinesis_event(
+        kinesis_event, deserializer=json.loads)
 
-    if len(output_events):
-        if output_stream_name:
-            logger.info("Sending {} events to output stream '{}' ...".format(
-                len(output_events), output_stream_name))
-            resp = utils.send_to_kinesis_stream(output_events,
-                                                output_stream_name)
-            if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
-                raise KinesisError(json.dumps(resp))
-            logger.info(resp)
-
-        if input_delivery_stream_name:
-            logger.info("Sending {} events to delivery stream '{}' ...".format(
-                len(output_events), input_delivery_stream_name))
-            resp = utils.send_to_delivery_stream(output_events,
-                                                 output_delivery_stream_name)
-            if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
-                raise FirehoseError(json.dumps(resp))
-            logger.info(resp)
-
-    if len(input_delivery_stream_name) > 0:
+    if input_delivery_stream_name:
         logger.info("Sending {} events to delivery stream '{}' ...".format(
             len(events), input_delivery_stream_name))
         resp = utils.send_to_delivery_stream(events,
                                              input_delivery_stream_name)
+        if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
+            raise FirehoseError(json.dumps(resp))
+        logger.info(resp)
+
+    logger.info("Going to transform {} events from shard '{}'".format(
+        len(events), shard_id))
+
+    logger.info("First input event: {}".format(
+        json.dumps(events[0], indent=4)))
+
+    logger.info("Applying {} callables: {}".format(len(callables), callables))
+
+    core.transform_events(events, callables, environment, layer, stage,
+                          shard_id)
+
+    logger.info("First transformed event: {}".format(
+        json.dumps(events[0], indent=4)))
+
+    if output_stream_name:
+        logger.info("Sending {} events to output stream '{}' ...".format(
+            len(events), output_stream_name))
+
+        logger.info("Using partition key: {}".format(partition_key))
+        resp = utils.send_to_kinesis_stream(events, output_stream_name,
+                                            partition_key=partition_key)
+        if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
+            raise KinesisError(json.dumps(resp))
+        logger.info(resp)
+    else:
+        logger.info("No output stream: will not deliver transformed events")
+
+    if output_delivery_stream_name:
+        logger.info("Sending {} events to delivery stream '{}' ...".format(
+            len(events), input_delivery_stream_name))
+        resp = utils.send_to_delivery_stream(events,
+                                             output_delivery_stream_name)
         if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
             raise FirehoseError(json.dumps(resp))
         logger.info(resp)

--- a/humilis_kinesis_mapper/meta.yaml.j2
+++ b/humilis_kinesis_mapper/meta.yaml.j2
@@ -15,6 +15,18 @@ meta:
         {% endfor %}
     {% endif %}
     parameters:
+        dynamodb_capacity:
+            description:
+                The read and write capacity for the Lambda state table(s)
+            value:
+                read: 5
+                write: 5
+        partition_key:
+            description:
+                A callable that produces the partition key that determines the 
+                target shard for output events. If not provided a random 
+                partition key will be used.
+            value:
         callables:
             description:
                 List of callables in dot-notation to call for every event in an input stream
@@ -47,6 +59,12 @@ meta:
                         parameters:
                             layer_name: {{streams[io].layer}}
                             output_name: {{streams[io].stream}}Arn
+                shard_count:
+                    ref:
+                        parser: output
+                        parameters:
+                            layer_name: {{streams[io].layer}}
+                            output_name: {{streams[io].stream}}ShardCount
         {% endif %}
         {% if delivery[io] %}
         {{io}}_delivery_stream:

--- a/humilis_kinesis_mapper/resources.yaml.j2
+++ b/humilis_kinesis_mapper/resources.yaml.j2
@@ -1,6 +1,6 @@
 ---
 resources:
-    {# The lambda function #}
+    # The lambda function
     LambdaFunction:
       Type: "AWS::Lambda::Function"
       Properties:
@@ -16,7 +16,7 @@ resources:
           "Fn::GetAtt":
               - LambdaExecutionRole
               - Arn
-    {# The role associated to the Lambda function that processes raw events #}
+    # The role associated to the Lambda function that processes raw events
     LambdaExecutionRole:
       Type: "AWS::IAM::Role"
       Properties:
@@ -27,7 +27,7 @@ resources:
               Principal:
                   Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
-        {# Keep all environment role under the same path #}
+        # Keep all environment role under the same path
         Path: {{ "/{}/".format(_env.name) }}
         Policies:
           - PolicyName: root
@@ -35,7 +35,7 @@ resources:
               Version: "2012-10-17"
               Statement:
                 - Effect: Allow
-                  {# Write access to Cloudwatch logs #}
+                  # Write access to Cloudwatch logs
                   Action:
                     - "logs:CreateLogGroup"
                     - "logs:CreateLogStream"
@@ -43,7 +43,7 @@ resources:
                   Resource: "arn:aws:logs:*:*:*"
                 {% if output_delivery_stream or input_delivery_stream or error_delivery_stream %}
                 - Effect: Allow
-                  {# Write access to the Firehose delivery stream(s) #}
+                  # Write access to the Firehose delivery stream(s)
                   Action:
                     - "firehose:PutRecord"
                     - "firehose:PutRecordBatch"
@@ -61,20 +61,20 @@ resources:
                     {% endif %}
                 {% endif %}
                 - Effect: Allow
-                  {# Permission to list and describe I/O streams #}
+                  # Permission to list and describe I/O streams
                   Action:
                     - "kinesis:DescribeStream"
                     - "kinesis:ListStreams"
                   Resource: "*"
                 - Effect: Allow
-                  {# Permissions to read from the input stream #}
+                  # Permissions to read from the input stream
                   Action:
                     - "kinesis:GetRecords"
                     - "kinesis:GetShardIterator"
                   Resource: {{ input_stream.arn }}
                   {% if output_stream or error_stream %}
                 - Effect: Allow
-                  {# Permissions to write to output stream #}
+                  # Permissions to write to output stream
                   Action:
                     - "kinesis:PutRecords"
                   Resource:
@@ -86,29 +86,36 @@ resources:
                     {% endif %}
                   {% endif %}
                 - Effect: Allow
-                  {# Permissions to access the DynamoDB secrets table #}
+                  # Permissions to access the DynamoDB secrets table
                   Action:
                     - "dynamodb:GetItem"
                   Resource: "*"
                 - Effect: Allow
+                  # Read/write permission on the associated state tables
                   Action:
                     - "dynamodb:*"
                   Resource:
+                    {% for shard in range(input_stream.shard_count|int()) %}
                     - "Fn::Join":
                       - ""
-                      - ["arn:aws:dynamodb:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "table/", {"Ref": "StateTable"}]
+                      - ["arn:aws:dynamodb:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "table/", {"Ref": "StateTable{{shard}}"}]
+                    {% endfor %}
     InputEventSourceMapping:
       Type: "AWS::Lambda::EventSourceMapping"
       Properties:
         BatchSize: {{ batch_size }}
-        {# The ARN of the input Kinesis stream #}
+        # The ARN of the input Kinesis stream
         EventSourceArn: {{ input_stream.arn }}
         FunctionName:
           Ref: LambdaFunction
         StartingPosition:
           TRIM_HORIZON
-    {# The DynamoDB table that keeps state information #}
-    StateTable:
+    # The DynamoDB tables that keep shard-specific state information
+    #
+    # Events in different shards of the input stream may be processed
+    # concurrently and thus we need a table per shard
+    {% for shard in range(input_stream.shard_count|int()) %}
+    StateTable{{shard}}:
       Type: "AWS::DynamoDB::Table"
       Properties:
         AttributeDefinitions:
@@ -119,10 +126,11 @@ resources:
           - AttributeName: id
             KeyType: HASH
         ProvisionedThroughput:
-          ReadCapacityUnits: 50
-          WriteCapacityUnits: 50
+          ReadCapacityUnits: {{dynamodb_capacity.read}}
+          WriteCapacityUnits: {{dynamodb_capacity.write}}
         {% if _env.stage %}
-        TableName: {{_env.name}}-{{_layer.name}}-{{_env.stage}}-state
+        TableName: {{_env.name}}-{{_layer.name}}-{{_env.stage}}-{{shard}}-state
         {% else %}
-        TableName: {{_env.name}}-{{_layer.name}}-state
+        TableName: {{_env.name}}-{{_layer.name}}-{{shard}}-state
         {% endif %}
+    {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,16 @@ from humilis_kinesis_mapper import __version__
 dirname = os.path.dirname(__file__)
 
 long_description = (
-    codecs.open(os.path.join(dirname, "README.rst"), encoding="utf-8").read() + "\n" +
-    codecs.open(os.path.join(dirname, "AUTHORS.rst"), encoding="utf-8").read() + "\n" +
+    codecs.open(os.path.join(dirname, "README.rst"), encoding="utf-8").read() + "\n" +   # noqa
+    codecs.open(os.path.join(dirname, "AUTHORS.rst"), encoding="utf-8").read() + "\n" +  # noqa
     codecs.open(os.path.join(dirname, "CHANGES.rst"), encoding="utf-8").read()
 )
 
 setup(
     name="humilis-kinesis-mapper",
     include_package_data=True,
-    packages=find_packages(include=['humilis_kinesis_mapper', 'humilis_kinesis_mapper.*']),
+    packages=find_packages(include=['humilis_kinesis_mapper',
+                                    'humilis_kinesis_mapper.*']),
     version=__version__,
     author="Anatoly Bubenkov, FindHotel and others",
     author_email="developers@innovativetravel.eu",
@@ -27,7 +28,7 @@ setup(
     long_description=long_description,
     install_requires=[
         "humilis>=0.4.1",
-        "lambdautils"],
+        "lambdautils>=0.2.11"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 2"

--- a/tests/integration/humilis-kinesis-mapper.yaml.j2
+++ b/tests/integration/humilis-kinesis-mapper.yaml.j2
@@ -9,16 +9,19 @@ humilis-kinesis-mapper:
         - layer: streams
           layer_type: streams
           streams:
+              # Use two shards to test support for multiple shards
               - name: InputStream
-                shard_count: 1
+                shard_count: 2
               - name: OutputStream
-                shard_count: 1
+                shard_count: 2
               - name: ErrorStream
                 shard_count: 1
 
-        # Parses user agents and adds a random UUID field
+        # Parses user agents. Stores also some state info to test
+        # support for stateful Lambdas and multi-shard streams.
         - layer: kinesis-mapper
           layer_type: kinesis-mapper
+          partition_key: myparserpkg.__init__:partition_key
           lambda_dependencies:
             - user-agents
             - mycode/myparserpkg

--- a/tests/integration/mycode/myparserpkg/__init__.py
+++ b/tests/integration/mycode/myparserpkg/__init__.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import lambdautils.utils as utils
 from user_agents import parse
 
 
@@ -10,7 +11,12 @@ def partition_key(event, **kwargs):
     return event.get("client_id", str(uuid.uuid4()))
 
 
-def parse_ua(event, **kwargs):
+def parse_ua(event, state_args=None):
     parsed = parse(event["user_agent"])
     event["device_family"] = parsed.device.family or ""
     event["device_brand"] = parsed.device.brand or ""
+
+    utils.set_state("my_state_key", "my_state_value", namespace="my_namespace",
+                    **state_args)
+    assert utils.get_state("my_state_key", namespace="my_namespace",
+                           **state_args) == "my_state_value"

--- a/tests/integration/mycode/myparserpkg/__init__.py
+++ b/tests/integration/mycode/myparserpkg/__init__.py
@@ -1,9 +1,16 @@
 """A sample Python package to test the layer."""
 
+import uuid
+
 from user_agents import parse
 
 
-def parse_ua(event):
+def partition_key(event, **kwargs):
+    """Produces the partition key for an event."""
+    return event.get("client_id", str(uuid.uuid4()))
+
+
+def parse_ua(event, **kwargs):
     parsed = parse(event["user_agent"])
     event["device_family"] = parsed.device.family or ""
     event["device_brand"] = parsed.device.brand or ""

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -18,6 +18,8 @@ def test_process_event(kinesis_event, event, context, boto3_client,
                   partition_key)
     # The processor should have inserted the records in the output stream
     assert boto3_client("kinesis").put_records.call_count == 1
-    cal.assert_called_once_with(event, environment="environment",
-                                layer="layer", stage="stage",
-                                shard_id="shardId-000000000000")
+    state_args = dict(
+        environment="environment",
+        layer="layer", stage="stage",
+        shard_id="shardId-000000000000")
+    cal.assert_called_once_with(event, state_args=state_args)

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1,13 +1,23 @@
 """Test the logic of the Lambda function."""
 from mock import Mock
 
-from humilis_kinesis_mapper.lambda_function.handler.processor.main import process_event
+from humilis_kinesis_mapper.lambda_function.handler.processor.main import process_event  # noqa
 
 
-def test_process_event(kinesis_event, event, context, boto3_client, monkeypatch):
+def test_process_event(kinesis_event, event, context, boto3_client,
+                       monkeypatch):
     """Process events."""
     cal = Mock()
-    process_event(kinesis_event, context, "input", "input_delivery", "output_delivery", [cal])
+    partition_key = lambda ev: ev.get("client_id", "")
+    process_event(kinesis_event, context,
+                  "output_stream", "input_delivery", "output_delivery",
+                  "environment",
+                  "layer",
+                  "stage",
+                  [cal],
+                  partition_key)
     # The processor should have inserted the records in the output stream
     assert boto3_client("kinesis").put_records.call_count == 1
-    cal.assert_called_once_with(event)
+    cal.assert_called_once_with(event, environment="environment",
+                                layer="layer", stage="stage",
+                                shard_id="shardId-000000000000")


### PR DESCRIPTION
Please review.

This should allow user-provided callables to read/write to the state table associated to a Lambda. It also supports multiple shards by having a separate DynamoDB table to keep the state of different shards.

User-provided callables can access the Lambda state table(s) like this:

```
import lambdautils.utils as utils

def my_callable(event, state_args=None):
    utils.set_state("my_state_key", "my_state_value", namespace="my_namespace", **state_args)
    assert utils.get_state("my_state_key", namespace="my_namespace", **state_args) == "my_state_value"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humilis/humilis-kinesis-mapper/3)
<!-- Reviewable:end -->
