### PR TITLE
Do not require input or error streams for deployment

### DIFF
--- a/humilis_kinesis_processor/resources.yaml.j2
+++ b/humilis_kinesis_processor/resources.yaml.j2
@@ -9,6 +9,9 @@
 {% set _ = globs.update({'has_output_delivery': True}) %}
 {% endif %}
 {% endfor %}
+# set meta_input and meta_error to empty dicts if the user has not provided them
+{% set meta_error = meta_error or {} %}
+{% set meta_input = meta_input or {} %}
 # Do we need a DynamoDB table to store state info?
 {% if dynamodb_capacity.read|int or dynamodb_capacity.write|int %}
 {% set _ = globs.update({'stateful': False}) %}
@@ -84,12 +87,14 @@ resources:
                     - "kinesis:DescribeStream"
                     - "kinesis:ListStreams"
                   Resource: "*"
+                {% if meta_input.kinesis_stream_arn %}
                 - Effect: Allow
                   # Permissions to read from the input stream
                   Action:
                     - "kinesis:GetRecords"
                     - "kinesis:GetShardIterator"
                   Resource: {{ meta_input.kinesis_stream_arn }}
+                  {% endif %}
                   {% if has_output_stream or meta_error.kinesis_stream_arn %}
                 - Effect: Allow
                   # Permissions to write to error and output streams
@@ -120,6 +125,7 @@ resources:
                       - ""
                       - ["arn:aws:dynamodb:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "table/", {"Ref": "StateTable"}]
                  {% endif %}
+    {% if meta_input.kinesis_stream_arn %}
     InputEventSourceMapping:
       Type: "AWS::Lambda::EventSourceMapping"
       Properties:
@@ -130,6 +136,7 @@ resources:
           Ref: LambdaFunction
         StartingPosition:
           TRIM_HORIZON
+    {% endif %}
     # The DynamoDB tables that keep shard-specific state information
     #
     # We use the same state table across shards. The lambdautils functions

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,11 +19,14 @@ def settings():
         streams_layer_name="streams")
 
 
-@pytest.fixture(scope="session")
+@pytest.yield_fixture(scope="session")
 def environment(settings):
-    """The lambda-processor-test humilis environment."""
+    """The test environment: this fixtures creates it and takes care of
+    removing it after tests have run."""
     env = Environment(settings.environment_path, stage=settings.stage)
-    return env
+    env.create()
+    yield env
+    env.delete()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_all.py
+++ b/tests/integration/test_all.py
@@ -21,8 +21,9 @@ def get_all_records(client, si, limit, timeout=10):
     return retrieved_recs
 
 
-def test_io_streams_put_get_record(kinesis, payloads, shard_iterators, events,
-                                   input_stream_name, output_stream_name):
+def test_io_streams_put_get_record(
+        environment, kinesis, payloads, shard_iterators, events,
+        input_stream_name, output_stream_name):
     """Put and read a record from the input stream."""
 
     # Put some records in the input stream


### PR DESCRIPTION
Please review. This make it possible to deploy the kinesis processor without any Kinesis stream associated to it. There are at least two reasons why you would like to do that:

* To speed up the testing of other layers that depent on a processor being available in your environment, but that do not require the presence of any Kinesis stream. For instance the secrets-vault layer.
* The user may want to attach streams to the processor manually using the console, e.g. for experimentation.