### PR TITLE
Support for user-provider stream names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.7.5
+-----
+
+- Users can also specify input/output/error streams by name instead of as
+  references to another layer outputs.
+
 0.6.8
 -----
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: .env
 	$(TOX) -e unit
 
 # run integration tests (require deployment)
-testi: .env update
+testi: .env
 	$(PIP) install tox
 	$(TOX) -e integration
 

--- a/humilis_kinesis_processor/__init__.py
+++ b/humilis_kinesis_processor/__init__.py
@@ -1,3 +1,3 @@
 """Humilis kinesis processor."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/humilis_kinesis_processor/meta.yaml.j2
+++ b/humilis_kinesis_processor/meta.yaml.j2
@@ -66,32 +66,30 @@ meta:
             value:
                 {% if s.kinesis_stream %}
                 kinesis_stream:
+                    {% if s.kinesis_stream is mapping %}
+                    {# if user is passing a reference to a layer output #}
                     ref:
                         parser: output
                         parameters:
                             layer_name: {{s.kinesis_stream.layer}}
                             output_name: {{s.kinesis_stream.name}}
-                kinesis_stream_arn:
-                    ref:
-                        parser: output
-                        parameters:
-                            layer_name: {{s.kinesis_stream.layer}}
-                            output_name: {{s.kinesis_stream.name}}Arn
+                    {% else %}
+                    {# else assume user is passing the name of the stream #}
+                    {{s.kinesis_stream}}
+                    {% endif %}
                 {% endif %}
-
                 {% if s.firehose_delivery_stream %}
                 firehose_delivery_stream:
+                    {% if s.firehose_delivery_stream is mapping %}
                     ref:
                         parser: output
                         parameters:
                             layer_name: {{s.firehose_delivery_stream.layer}}
                             output_name: {{s.firehose_delivery_stream.name}}
-                firehose_delivery_stream_arn:
-                    ref:
-                        parser: output
-                        parameters:
-                            layer_name: {{s.firehose_delivery_stream.layer}}
-                            output_name: {{s.firehose_delivery_stream.name}}Arn
+                    {% else %}
+                    {# user is passing directly the name of the delivery stream #}
+                    {{s.firehose_delivery_stream}}
+                    {% endif %}
                 {% endif %}
                 mapper: "{{s.mapper}}"
                 filter: "{{s.filter}}"
@@ -105,40 +103,36 @@ meta:
                 Settings for the output event stream(s)
             value:
                 {% for s in output %}
-                -
+                - mapper: "{{s.mapper}}"
+                  filter: "{{s.filter}}"
+                  partition_key: {{s.partition_key}}
                   {% if s.kinesis_stream %}
                   kinesis_stream:
+                      {% if s.kinesis_stream is mapping %}
+                      {# user is passing a reference to another layer output #}
                       ref:
                           parser: output
                           parameters:
                               layer_name: {{s.kinesis_stream.layer}}
                               output_name: {{s.kinesis_stream.name}}
-                  kinesis_stream_arn:
-                      ref:
-                          parser: output
-                          parameters:
-                              layer_name: {{s.kinesis_stream.layer}}
-                              output_name: {{s.kinesis_stream.name}}Arn
+                      {% else %}
+                      {# user is passing directly the name of the stream #}
+                      {{s.kinesis_stream}}
+                      {% endif %}
                   {% endif %}
-
                   {% if s.firehose_delivery_stream %}
                   firehose_delivery_stream:
+                      {% if s.firehose_delivery_stream is mapping %}
+                      {# user is passing a reference to another layer output #}
                       ref:
                           parser: output
                           parameters:
                               layer_name: {{s.firehose_delivery_stream.layer}}
                               output_name: {{s.firehose_delivery_stream.name}}
-                  firehose_delivery_stream_arn:
-                      ref:
-                          parser: output
-                          parameters:
-                              layer_name: {{s.firehose_delivery_stream.layer}}
-                              output_name: {{s.firehose_delivery_stream.name}}Arn
+                      {% else %}
+                      {{s.firehose_delivery_stream}}
+                      {% endif %}
                   {% endif %}
-
-                  mapper: {{s.mapper}}
-                  filter: {{s.filter}}
-                  partition_key: {{s.partition_key}}
                 {% endfor %}
         {% endif %}
 

--- a/humilis_kinesis_processor/resources.yaml.j2
+++ b/humilis_kinesis_processor/resources.yaml.j2
@@ -71,14 +71,20 @@ resources:
                     - "firehose:DescribeDeliveryStream"
                   Resource:
                     {% if meta_input.firehose_delivery_stream %}
-                    - {{meta_input.firehose_delivery_stream_arn}}
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:firehose:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "deliverystream/", "{{meta_input.firehose_delivery_stream}}"]
                     {% endif %}
                     {% if meta_error.firehose_delivery_stream %}
-                    - {{meta_error.firehose_delivery_stream_arn}}
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:firehose:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "deliverystream/", "{{meta_error.firehose_delivery_stream}}"]
                     {% endif %}
                     {% for os in meta_output %}
                     {% if os.firehose_delivery_stream %}
-                    - {{ os.firehose_delivery_stream_arn }}
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:firehose:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "deliverystream/", "{{os.firehose_delivery_stream}}"]
                     {% endif %}
                     {% endfor %}
                 {% endif %}
@@ -88,27 +94,34 @@ resources:
                     - "kinesis:DescribeStream"
                     - "kinesis:ListStreams"
                   Resource: "*"
-                {% if meta_input.kinesis_stream_arn %}
+                {% if meta_input.kinesis_stream %}
                 - Effect: Allow
                   # Permissions to read from the input stream
                   Action:
                     - "kinesis:GetRecords"
                     - "kinesis:GetShardIterator"
-                  Resource: {{ meta_input.kinesis_stream_arn }}
+                  Resource:
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:kinesis:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "stream/", "{{meta_input.kinesis_stream}}"]
                   {% endif %}
-                  {% if has_output_stream or meta_error.kinesis_stream_arn %}
+                  {% if has_output_stream or meta_error.kinesis_stream %}
                 - Effect: Allow
                   # Permissions to write to error and output streams
                   Action:
                     - "kinesis:PutRecords"
                   Resource:
                     {% for os in meta_output %}
-                    {% if os.kinesis_stream_arn %}
-                    - {{ os.kinesis_stream_arn}}
+                    {% if os.kinesis_stream %}
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:kinesis:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "stream/", "{{os.kinesis_stream}}"]
                     {% endif %}
                     {% endfor %}
-                    {% if meta_error.kinesis_stream_arn %}
-                    - {{meta_error.kinesis_stream_arn}}
+                    {% if meta_error.kinesis_stream %}
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:kinesis:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "stream/", "{{meta_error.kinesis_stream}}"]
                     {% endif %}
                   {% endif %}
                 - Effect: Allow
@@ -132,13 +145,16 @@ resources:
                       - ""
                       - ["arn:aws:dynamodb:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "table/", {"Ref": "StateTable"}]
                  {% endif %}
-    {% if meta_input.kinesis_stream_arn %}
+    {% if meta_input.kinesis_stream %}
     InputEventSourceMapping:
       Type: "AWS::Lambda::EventSourceMapping"
       Properties:
         BatchSize: {{ batch_size }}
         # The ARN of the input Kinesis stream
-        EventSourceArn: {{ meta_input.kinesis_stream_arn }}
+        EventSourceArn:
+            "Fn::Join":
+              - ""
+              - ["arn:aws:kinesis:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "stream/", "{{meta_input.kinesis_stream}}"]
         FunctionName:
           Ref: LambdaFunction
         StartingPosition:

--- a/tests/integration/humilis-kinesis-processor.yaml.j2
+++ b/tests/integration/humilis-kinesis-processor.yaml.j2
@@ -11,7 +11,7 @@ humilis-kinesis-processor:
           streams:
               # Use two shards to test support for multiple shards
               - name: InputStream
-                shard_count: 2
+                shard_count: 1
               - name: OutputStream1
                 shard_count: 2
               - name: OutputStream2


### PR DESCRIPTION
This allows users to specify input/output/error streams by name instead as references to another layer outputs. It also refactors a bit the meta.yaml file so that ARNs are not necessary anymore to be specified there: they are computed from the stream names in the resources.yaml file.

Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humilis/humilis-kinesis-processor/11)
<!-- Reviewable:end -->
