### PR TITLE
Support for one-to-many mappers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.7.6
+-----
+
+- Support for one-to-many mappers
+
 0.7.5
 -----
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import json
 import uuid
 
 
-NB_EVENTS = 5
+NB_EVENTS = 2
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1,9 +1,13 @@
 """Test the logic of the Lambda function."""
+
+import copy
+
 from mock import Mock
 
 import pytest
 
 from humilis_kinesis_processor.lambda_function.handler.processor import process_event  # noqa
+from lambdautils.exception import CriticalError
 
 
 def _identity(ev, state_args=None, **kwargs):
@@ -16,80 +20,66 @@ def _all(ev, state_args=None, **kwargs):
     return True
 
 
+def _dupper(ev, state_args=None, **kwargs):
+    """Duplicates every input event."""
+    return [ev, ev]
+
+
 def _none(ev, state_args=None, **kwargs):
     """A pass-none filter callable."""
     return False
 
 
-_input = {
-    "kinesis_stream": "iks",
-    "firehose_delivery_stream": "ifhs",
-    "mapper": Mock(side_effect=_identity),
-    "filter": Mock(side_effect=_all)}
+def _make_input(filter=None, mapper=None, kstream=None):
+    input = {}
+    if filter is not None:
+        input["filter"] = Mock(side_effect=filter)
+    if mapper is not None:
+        input["mapper"] = Mock(side_effect=mapper)
+    if kstream is not None:
+        input["kinesis_stream"] = kstream
+
+    return input
 
 
-_output = [{
-    "kinesis_stream": "oks1",
-    "firehose_delivery_stream": "ofhs1",
-    "mapper": Mock(side_effect=_identity),
-    "filter": Mock(side_effect=_all),
-    "partition_key": Mock(size_effect=lambda ev: ev.get("client_id"))
-    },
-    {
-    "kinesis_stream": "oks2",
-    "firehose_delivery_stream": "ofhs2",
-    "mapper": Mock(side_effect=_identity),
-    "filter": Mock(side_effect=_all)
-    }]
+def _make_output(filter=None, mapper=None, kstream=None, fstream=None, n=1):
+    o = {}
+    if filter is not None:
+        o["filter"] = Mock(side_effect=filter)
+    if mapper is not None:
+        o["mapper"] = Mock(side_effect=mapper)
+    if kstream is not None:
+        o["kinesis_stream"] = kstream
+    if fstream is not None:
+        o["firehose_delivery_stream"] = fstream
+
+    return [copy.deepcopy(o) for _ in range(n)]
 
 
 @pytest.mark.parametrize(
     "e,l,s,i,os,kputs,fputs", [
         ["e", "l", "s",
-            {
-                "kinesis_stream": "iks",
-            },
-            [
-                {
-                    "kinesis_stream": "oks1",
-                    "firehose_delivery_stream": "ofhs1",
-                    "mapper": Mock(side_effect=_identity),
-                    "filter": Mock(side_effect=_all)},
-                {
-                    "kinesis_stream": "oks2",
-                    "firehose_delivery_stream": "ofhs2",
-                    "mapper": Mock(side_effect=_identity),
-                    "filter": Mock(side_effect=_none)}
-                ],
-            1, 1],
-        ["e", "l", "s", _input, _output, 2, 3],
+         _make_input(kstream="k"),
+         _make_output(_all, _dupper, "k", "f", 2), 2, 2],
         ["e", "l", "s",
-            {
-                "kinesis_stream": "iks",
-            },
-            [{
-                "kinesis_stream": "oks1",
-                "firehose_delivery_stream": "ofhs1",
-                "mapper": Mock(side_effect=_identity),
-                "filter": Mock(side_effect=_all)}],
-            1, 1],
+         _make_input(kstream="k"),
+         _make_output(_all, _identity, "k", "f", 2), 2, 2],
         ["e", "l", "s",
-            {
-                "kinesis_stream": "iks",
-                "filter": Mock(side_effect=_none)
-            },
-            [{
-                "kinesis_stream": "oks1",
-                "firehose_delivery_stream": "ofhs1",
-                "mapper": Mock(side_effect=_identity),
-                "filter": Mock(side_effect=_all)}],
-            0, 0],
-        ["e", "l", "s", _input, [], 0, 1],
+         _make_input(kstream="k"),
+         _make_output(_all, _identity, "k", None, 2), 2, 0],
         ["e", "l", "s",
-            {
-                "kinesis_stream": "iks",
-            },
-            [], 0, 0]
+         _make_input(kstream="k"),
+         _make_output(_all, _identity, None, "k", 2), 0, 2],
+        ["e", "l", "s",
+         _make_input(kstream="k"),
+         _make_output(_all, _identity, None, None, 2), 0, 0],
+        ["e", "l", "s",
+         _make_input(_none, None, "k"),
+         _make_output(_all, _identity, "k", "f"), 0, 0],
+        ["e", "l", "s",
+         _make_input(_all, _identity, "k"),
+         _make_output(_none, _identity, "k", "f", 2), 0, 0],
+        ["e", "l", "s", [], [], 0, 0]
         ])
 def test_process_event(e, l, s, i, os, kputs, fputs, kinesis_event, events,
                        context, boto3_client, monkeypatch):
@@ -99,12 +89,21 @@ def test_process_event(e, l, s, i, os, kputs, fputs, kinesis_event, events,
     assert boto3_client("kinesis").put_records.call_count == kputs
     assert boto3_client("firehose").put_record_batch.call_count == fputs
 
-    ifilter = i.get("filter")
+    if i:
+        ifilter = i.get("filter")
+    else:
+        ifilter = None
+
     if ifilter:
         assert ifilter.call_count == len(events)
         # Need to reset the call count because events is a parametrized fixture
         ifilter.reset_mock()
-    imapper = i.get("mapper")
+
+    if i:
+        imapper = i.get("mapper")
+    else:
+        imapper = None
+
     if imapper:
         if ifilter is None or ifilter.side_effect == _all:
             assert imapper.call_count == len(events)
@@ -139,3 +138,14 @@ def test_process_event(e, l, s, i, os, kputs, fputs, kinesis_event, events,
 
         if pk:
             pk.reset_mock()
+
+
+def test_bad_callable(kinesis_event, context):
+    """Bad mappers should raise an exception."""
+
+    def bad_mapper(ev, context):
+        return "I should never return a string!"
+
+    os = [{"mapper": Mock(side_effect=bad_mapper)}]
+    with pytest.raises(CriticalError):
+        process_event(kinesis_event, context, "e", "l", "s", [], os)


### PR DESCRIPTION
We should have something similar in the push-processor plug-in. Probably at some point we should have just one generic processor that can handle both the Kinesis pull event model and the push notification model.

Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humilis/humilis-kinesis-processor/13)
<!-- Reviewable:end -->
